### PR TITLE
Replacements via ghsed

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,9 +1,1 @@
-{
-  "directory": "bower_components",
-  "registry": {
-    "search": [
-      "http://registry.origami.ft.com",
-      "https://bower.herokuapp.com"
-    ]
-  }
-}
+{"directory":"bower_components","registry":{"search":["https://origami-bower-registry.ft.com","https://bower.herokuapp.com"]}}

--- a/client/styles/_functions.scss
+++ b/client/styles/_functions.scss
@@ -1,6 +1,6 @@
 // The `ftFont` function is a shortcut to get the proper name of an FT font (plus fallbacks) from o-fonts
 //   EXAMPLE: ftFont('FinancierTextWeb'); // returns "FinancierTextWeb, serif"
-//   See http://registry.origami.ft.com/components/o-fonts
+//   See https://origami-bower-registry.ft.com/components/o-fonts
 
 @function ftFont($name) {
   @return oFontsGetFontFamilyWithFallbacks($name);
@@ -9,7 +9,7 @@
 
 // The `ftColor` function is a shortcut to get a hex colour from o-colors
 //   EXAMPLE: ftColor('pink'); // returns #fff1e0
-//   See http://registry.origami.ft.com/components/o-colors
+//   See https://origami-bower-registry.ft.com/components/o-colors
 
 @function ftColor($name) {
   @return oColorsGetPaletteColor($name);


### PR DESCRIPTION
Command invoked 2017-10-20T13:26:31.500Z with the following arguments:
```bash
$ ghsed s/http:\/\/registry.origami/https:\/\/origami-bower-registry/i ft-interactive/*/.bowerrc
```